### PR TITLE
Enable Product Action For Complex Query with 'id' key

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 WWW::GoDaddy::REST history
 
+Release 0.8.0 - 17th December 2014
+ - fix query url when querying resources with an 'id' search filter
+
 Release 0.7.0 - 9th July 2014
  - fix collection search to return appropriate resource objects
 

--- a/lib/WWW/GoDaddy/REST/Schema.pm
+++ b/lib/WWW/GoDaddy/REST/Schema.pm
@@ -103,7 +103,14 @@ sub query {
 sub query_complex {
     my $self = shift;
 
-    my $url = build_complex_query_url( $self->query_url, @_ );
+    my $id = delete $_[0]->{'id'};
+    my $url;
+    if ( defined $id ) {
+        $url = build_complex_query_url( $self->query_url($id), @_ );
+    }
+    else {
+        $url = build_complex_query_url( $self->query_url, @_ );
+    }
 
     my $resource = $self->client->http_request_as_resource( 'GET', $url );
 

--- a/t/crud.t
+++ b/t/crud.t
@@ -117,6 +117,22 @@ subtest 'query' => sub {
     is( $item->f('request_method'), "GET",          "requested method is good" );
     is( $item->f('request_uri'), "$URL_BASE/echoResponses?name=bar", "requested URI is good" );
     is( $item->f('request_content'), '', "requested content is empty" );
+
+    my $id = '123';
+    @items = $client->query(
+        'echoResponse',
+        {   'id'           => $id,
+            'showAccounts' => [
+                { 'value' => 'true' }    # implicit 'eq'
+            ],
+        }
+    );
+    ($item) = @items;
+    is( $item->type,                'echoResponse', 'correct item type returned' );
+    is( $item->f('request_method'), "GET",          "requested method is good" );
+    is( $item->f('request_uri'), sprintf( '%s/echoResponses/%s?showAccounts=true', $URL_BASE, $id ), "requested URI is good" );
+    is( $item->f('request_content'), '', "requested content is empty" );
+
 };
 
 subtest 'non resource responding' => sub {


### PR DESCRIPTION
Fix the query url for a resource action whenever there is a complex query with an 'id' key.
